### PR TITLE
Se agrego endpoint de update comments

### DIFF
--- a/OngProject/Controllers/CommentController.cs
+++ b/OngProject/Controllers/CommentController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using AutoMapper;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OngProject.Core.Models;
 using OngProject.Core.Models.DTOs;
@@ -54,6 +55,35 @@ namespace OngProject.Controllers
                 _unitOfWork.Commit();
 
             return Created("Created", new { Response = StatusCode(201) });
+        }
+
+        [HttpPut]
+        [Route("/comments/{id}")]
+        //[Authorize(Roles = "admin")]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CommentDTO))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)] 
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(int id, CommentDTO commentDTO)
+        {
+            var entity = await _commentService.GetById(id);
+
+            var user = await _userService.GetById(commentDTO.user_id);
+
+            if (ModelState.IsValid && entity != null)
+            {
+                if (user == null || entity.user_id != user.Id)
+                    return StatusCode(StatusCodes.Status403Forbidden);
+                else
+                {
+                    _commentService.UpdateComment(entity, commentDTO);
+                    _unitOfWork.Commit();
+                    return new OkObjectResult(commentDTO);
+                }
+            }
+            else
+            {
+                return NotFound();
+            }               
         }
     }
 }


### PR DESCRIPTION
COMO usuario
QUIERO actualizar un comentario propio
PARA mantener la información actualizada

Criterios de aceptación:
PUT /comments/:id - Deberá validar la existencia del comentario en base a su id. Solamente podrán editar un comentario el usuario que lo realizó o un administrador. Deberá devolver un código de error 404 si el comentario no existe, o 403 si no tiene permiso para modificarlo.