### PR TITLE
Adding Testimony Delete Controller

### DIFF
--- a/OngProject/Controllers/TestimonialController.cs
+++ b/OngProject/Controllers/TestimonialController.cs
@@ -71,6 +71,21 @@ namespace OngProject.Controllers
 
             return new OkObjectResult(testimonialsDTO);
         }
+
+        [HttpDelete]
+        [Route("/testimonials/{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var testimonials = await _testimonialService.GetById(id);
+
+            if (testimonials == null)
+                return BadRequest();
+
+            _testimonialService.DeleteTestimonial(testimonials);
+            _unitOfWork.Commit();
+
+            return Ok(testimonials);
+        }
     }
 
     

--- a/OngProject/Services/Interfaces/ITestimonialService.cs
+++ b/OngProject/Services/Interfaces/ITestimonialService.cs
@@ -6,5 +6,6 @@ namespace OngProject.Services.Interfaces
     public interface ITestimonialService : IGenericService<Testimonials>
     {
         void UpdateTestimonial(Testimonials testimonial, TestimonialDTO editTestimonialDTO);
+        void DeleteTestimonial(Testimonials testimonial);
     }
 }

--- a/OngProject/Services/TestimonialService.cs
+++ b/OngProject/Services/TestimonialService.cs
@@ -2,6 +2,7 @@
 using OngProject.Core.Models.DTOs;
 using OngProject.Repositories.Interfaces;
 using OngProject.Services.Interfaces;
+using System;
 
 namespace OngProject.Services
 {
@@ -19,6 +20,12 @@ namespace OngProject.Services
             testimonial.Image = editTestimonialDTO.Image;
             testimonial.Content = editTestimonialDTO.Content;
 
+            await _testimonialRepository.Update(testimonial);
+        }
+
+        public async void DeleteTestimonial(Testimonials testimonial)
+        {
+            testimonial.DeletedAt = DateTime.Now;
             await _testimonialRepository.Update(testimonial);
         }
     }


### PR DESCRIPTION
Se agrega: 
El endpoint para eliminar un testimony.
El método que elimina al testimony en el service correspondiente. No hace un delete en la BBDD, solo agrega la fecha de eliminación al campo DeleteAT (soft delete).

![CapturaDelete1](https://user-images.githubusercontent.com/58792586/188335829-ab30a019-8c0b-4786-ba7c-948bf4872148.JPG)
![CapturaDelete2](https://user-images.githubusercontent.com/58792586/188335833-a17b73de-2848-4913-9bfb-c6069dc9086d.JPG)
