### PR TITLE
Se agrego endpoint delete a commentsController

### DIFF
--- a/OngProject/Controllers/CommentController.cs
+++ b/OngProject/Controllers/CommentController.cs
@@ -80,10 +80,35 @@ namespace OngProject.Controllers
                     return new OkObjectResult(commentDTO);
                 }
             }
-            else
+            
+            return NotFound();                         
+        }
+
+        [HttpDelete]
+        [Route("/comments/{id}")]
+        //[Authorize(Roles = "admin")]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CommentDTO))]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Delete(int id, DeleteCommentDTO commentDTO)
+        {
+            var entity = await _commentService.GetById(id);
+
+            var user = await _userService.GetById(commentDTO.user_id);
+
+            if (ModelState.IsValid && entity != null)
             {
-                return NotFound();
-            }               
+                if (user == null || entity.user_id != user.Id)
+                    return StatusCode(StatusCodes.Status403Forbidden);
+                else
+                {
+                    await _commentService.DeleteAsync(entity);
+                    _unitOfWork.Commit();
+                    return Ok();
+                }
+            }
+
+            return NotFound();
         }
     }
 }

--- a/OngProject/Core/Models/DTOs/DeleteCommentDTO.cs
+++ b/OngProject/Core/Models/DTOs/DeleteCommentDTO.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace OngProject.Core.Models.DTOs
+{
+    public class DeleteCommentDTO
+    {
+        [Required(ErrorMessage = "user_id is required")]
+        public string user_id { get; set; }
+    }
+}


### PR DESCRIPTION
COMO usuario
QUIERO borrar un comentario
PARA moderar el contenido

Criterios de aceptación:
DELETE /comments/:id - Deberá validar la existencia del comentario. Solamente podrán eliminar un comentario el usuario creador del mismo o un administrador. Deberá devolver un código de error 404 si el comentario no existe, o 403 si no tiene permiso para modificarlo.