### PR TITLE
OT280-64-slidesGetAll

### DIFF
--- a/OngProject/Controllers/SlideController.cs
+++ b/OngProject/Controllers/SlideController.cs
@@ -14,6 +14,10 @@ using System;
 using OngProject.Services;
 using Microsoft.IdentityModel.Tokens;
 using EllipticCurve.Utils;
+using Microsoft.EntityFrameworkCore;
+using OngProject.Core.Models.DTOs;
+using System.Collections.Generic;
+using System.Xml.Linq;
 
 namespace OngProject.Controllers
 {
@@ -45,7 +49,6 @@ namespace OngProject.Controllers
         /// <summary>
         /// Crear Slide con imagen en base64
         /// </summary>
-        /// <returns>Token de acceso</returns>
         /// <remarks>
         /// Sample request:
         ///
@@ -68,14 +71,12 @@ namespace OngProject.Controllers
         ///         }
         ///     }
         /// </remarks>
-        /// <response code="200">Solicitud concretada con exito</response>
-        [HttpPost]
+        /// <response code="201">Creada con exito</response>
+        [HttpPost()]
         public async Task<IActionResult> CreateSlideImageB64(SlideCreateDTO newSlide)
         {
             if (!ModelState.IsValid)
                 return BadRequest();
-
-            var _slide = _mapper.Map<Slide>(newSlide);
 
             var putRequest = _awsS3Service.PutObjectRequestImageBase64(newSlide.ImageBase64, newSlide.ImageName);
 
@@ -87,12 +88,15 @@ namespace OngProject.Controllers
             var slide = await _slideService.GetAllAsync();
             var slideTable = _mapper.Map<Slide>(slide.OrderByDescending(x => x.Order).First());
 
+            var _slide = _mapper.Map<Slide>(newSlide);
+
             if (slide == null)
                 _slide.Order = 1;
             else
                 _slide.Order = slideTable.Order + 1;
 
-            _slide.ImageUrl = newSlide.ImageName;
+            _slide.ImageUrl = _awsS3Service.GetUrlRequest("slides/" + newSlide.ImageName);
+            //_slide.ImageUrl = newSlide.ImageName;
 
             var created = await _slideService.CreateAsync(_slide);
 
@@ -101,8 +105,20 @@ namespace OngProject.Controllers
 
             return Created("Created", new { Response = StatusCode(201) });
         }
-        
-        [HttpPost("IFromFile")]
+
+        /// <summary>
+        /// Subir imagen con upload al bucket - jpg o png
+        /// </summary>
+        /// <remarks>
+        /// Sample request:
+        ///
+        ///     POST /slide
+        ///     {
+        ///         upload file
+        ///     }
+        /// </remarks>
+        /// <response code="201">Creada con exito</response>
+        [HttpPost("File")]
         public async Task<IActionResult> CreateSlideFile(IFormFile file)
         {
             if (!ModelState.IsValid)
@@ -114,6 +130,7 @@ namespace OngProject.Controllers
             return Ok(result);
         }
 
+        #region No se puede combinar multipart/form data con IFormFile
         //IFormFile es solo para solicitudes codificadas de datos de formulario/varias partes,
         //y no puede mezclar y combinar codificaciones de cuerpo de solicitud cuando usa ModelBinder.
         //Por lo tanto, tendría que dejar de usar JSON o enviar el archivo en el objeto JSON,
@@ -143,36 +160,55 @@ namespace OngProject.Controllers
 
         //    return Created("Created", new { Response = StatusCode(201) });
         //}
-        
-        [HttpGet]
-        public async Task<IActionResult> Get(string imageName)
-        {
-            var response = await _amazonS3.GetObjectAsync(BucketName, "slides/" +imageName);
-            return File(response.ResponseStream, response.Headers.ContentType);
-        }
+        #endregion
 
+        #region imagen con nombre del objeto en el bucket
+        //[HttpGet("Image")]
+        //public async Task<IActionResult> Get(string imageName)
+        //{
+        //    var response = await _amazonS3.GetObjectAsync(BucketName, "slides/" + imageName);
+        //    return File(response.ResponseStream, response.Headers.ContentType);
+        //}
+        #endregion
+
+        #region test para ver la urls de una lista de objetos
         // test para ver la urls de una lista de objetos
         // tiene time expire
-        [HttpGet("GetUrls")]
-        public async Task<IActionResult> GetList(string prefix)
+        //[HttpGet("GetUrls")]
+        //public async Task<IActionResult> GetList(string prefix)
+        //{
+        //    var request = _awsS3Service.ListObjectV2(prefix);
+
+        //    var response = await _amazonS3.ListObjectsV2Async(request);
+        //    var preSignedUrls = response.S3Objects.Select(o =>
+        //    {
+        //        var request = new GetPreSignedUrlRequest()
+        //        {
+        //            BucketName = BucketName,
+        //            Key = o.Key,
+        //            Expires = System.DateTime.UtcNow.AddDays(1)
+        //        };
+        //        return _amazonS3.GetPreSignedURL(request);
+        //    });
+
+        //    return Ok(preSignedUrls);
+        //}
+        #endregion
+
+        [HttpGet()]
+        public async Task<IActionResult> GetAll()
         {
-            var request = _awsS3Service.ListObjectV2(prefix);
+            var slide = _unitOfWork.Context.Slides.AsQueryable();
 
-            var response = await _amazonS3.ListObjectsV2Async(request);
-            var preSignedUrls = response.S3Objects.Select(o =>
-            {
-                var request = new GetPreSignedUrlRequest()
-                {
-                    BucketName = BucketName,
-                    Key = o.Key,
-                    Expires = System.DateTime.UtcNow.AddDays(1)
-                };
-                return _amazonS3.GetPreSignedURL(request);
-            });
+            slide = slide.OrderBy(s => s.Order);
 
-            return Ok(preSignedUrls);
+            var slides = await slide.AsNoTracking().ToListAsync();
+
+            var slideDTO = _mapper.Map<IEnumerable<SlideListDTO>>(slides);
+
+            return new OkObjectResult(slideDTO);
         }
-              
+
         [HttpGet("{id}")]
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SlideDTO))]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -182,29 +218,22 @@ namespace OngProject.Controllers
             if (slide == null)
                 return NotFound();
 
-            var response = await _amazonS3.GetObjectAsync(BucketName, slide.ImageUrl);
-
-            var request = new GetPreSignedUrlRequest()
-            {
-                BucketName = BucketName,
-                Key = response.Key,
-                Expires = System.DateTime.UtcNow.AddSeconds(40)
-            };
-            var preSignedUrls = _amazonS3.GetPreSignedURL(request);
-
-
-            var slideDTO = _mapper.Map<SlideListDTO>(slide);
+            var slideDTO = _mapper.Map<SlideDTO>(slide);
 
             return new OkObjectResult(slideDTO);
         }
         
-        [HttpGet("GetImageById")]
+        [HttpGet("ImageById/{id}")]
         public async Task<IActionResult> GetImageById(int id)
         {
             var slide = await _slideService.GetById(id);
             if (slide is null)
                 return NotFound();
-            var response = await _amazonS3.GetObjectAsync(BucketName, slide.ImageUrl);
+
+            string[] split1 = slide.ImageUrl.Split("?");
+            string[] image = split1[0].Split("/");
+
+            var response = await _amazonS3.GetObjectAsync(BucketName, "slides/" + image[4].ToString());
             return File(response.ResponseStream, response.Headers.ContentType);
         }
 
@@ -237,5 +266,11 @@ namespace OngProject.Controllers
             return Ok(slide);
         }
 
+        //[HttpDelete("DeleteImage")]
+        //public async Task<IActionResult> Delete(string imageName)
+        //{
+        //    var response = await _amazonS3.GetObjectAsync(BucketName, "slides/" + imageName);
+        //    return File(response.ResponseStream, response.Headers.ContentType);
+        //}
     }
 }

--- a/OngProject/Core/Mapper/EntityMapper.cs
+++ b/OngProject/Core/Mapper/EntityMapper.cs
@@ -36,6 +36,7 @@ namespace OngProject.Core.Mapper
             CreateMap<ActivityDTO, Activities>();
 
             CreateMap<Organization, OrganizationDTO>();
+            CreateMap<OrganizationDTO, Organization>();
 
             CreateMap<Testimonials, TestimonialDTO>();
             CreateMap<TestimonialDTO, Testimonials>();
@@ -48,6 +49,7 @@ namespace OngProject.Core.Mapper
             // Slides
             CreateMap<Slide, SlideDTO>();
             CreateMap<SlideDTO, Slide>();
+            CreateMap<Slide, Slide>();
             CreateMap<Slide, SlideCreateDTO>();
             CreateMap<SlideCreateDTO, Slide>();
             CreateMap<Slide, SlideListDTO>();

--- a/OngProject/Core/Models/DTOs/OrganizationDTO.cs
+++ b/OngProject/Core/Models/DTOs/OrganizationDTO.cs
@@ -13,12 +13,11 @@ namespace OngProject.Core.Models.DTOs
         [StringLength(100)]
         public string Image { get; set; }
 
-
         [StringLength(100)]
         public string? Address { get; set; }
 
-        [Phone(ErrorMessage = "El formato del campo debe corresponder al de un número telefonico")]
-        [Range(0, 20, ErrorMessage = " El valor del campo debe ser un número entre 0 y 20")]
+        //[Phone(ErrorMessage = "El formato del campo debe corresponder al de un número telefonico")]
+        //[Range(0, 20, ErrorMessage = " El valor del campo debe ser un número entre 0 y 20")]
         public int? Phone { get; set; }
 
         [StringLength(256)]

--- a/OngProject/Core/Models/DTOs/Slide/SlideCreateDTO.cs
+++ b/OngProject/Core/Models/DTOs/Slide/SlideCreateDTO.cs
@@ -17,8 +17,8 @@ namespace OngProject.Core.Models.DTOs.Slide
 
         public int Order { get; set; }
 
-        [ForeignKey("Organization")]
-        public int OrganizationId { get; set; }
+        //[ForeignKey("Organization")]
+        //public int OrganizationId { get; set; }
 
         public Organization Organization { get; set; }
     }

--- a/OngProject/Core/Models/DTOs/Slide/SlideDTO.cs
+++ b/OngProject/Core/Models/DTOs/Slide/SlideDTO.cs
@@ -1,13 +1,17 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace OngProject.Core.Models.DTOs.Slide
 {
     public class SlideDTO
     {
-        [Required]
-        [MaxLength(255)]
         public string ImageUrl { get; set; }
 
+        public string Text { get; set; }
+
         public int Order { get; set; }
+
+        [ForeignKey("Organization")]
+        public int OrganizationId { get; set; }
     }
 }

--- a/OngProject/Core/Models/DTOs/Slide/SlideListDTO.cs
+++ b/OngProject/Core/Models/DTOs/Slide/SlideListDTO.cs
@@ -2,9 +2,7 @@
 {
     public class SlideListDTO
     {
-        public string Text { get; set; }
+        public string ImageUrl { get; set; }
         public int Order { get; set; }
-        public int OrganizationId { get; set; }
-
     }
 }

--- a/OngProject/Services/AWSS3Service.cs
+++ b/OngProject/Services/AWSS3Service.cs
@@ -10,7 +10,7 @@ namespace OngProject.Services
 {
     public class AWSS3Service : IAWSS3Service
     {
-        private string BucketName = "cohorte-agosto-38d749a7";
+        private readonly string BucketName = "cohorte-agosto-38d749a7";
 
         private readonly IUnitOfWork _unitOfWork;
 
@@ -60,20 +60,33 @@ namespace OngProject.Services
             }
             
             IFormFile file;
-            file = new FormFile(stream, 0, bytes.Length, ImageName, ImageName)
+            file = new FormFile(stream, 0, bytes.Length, ImageName, "slides/" +ImageName)
             {
                 Headers = new HeaderDictionary(),
                 ContentType = contentType
             };
 
-            return new PutObjectRequest()
+            return PutRequest(file);
+        }
+
+        public string GetUrlRequest(string ImageName)
+        {
+            // Create a client
+            AmazonS3Client client = new();
+
+            // Create a CopyObject request
+            GetPreSignedUrlRequest request = new()
             {
                 BucketName = BucketName,
-                Key = "slides/" + file.FileName,
-                InputStream = file.OpenReadStream(),
-                ContentType = file.ContentType,
+                Key = ImageName,
+                Expires = DateTime.Now.AddMonths(2)
             };
 
+            // Get path for request
+            return  client.GetPreSignedURL(request);
+
         }
+
+
     }
 }

--- a/OngProject/Services/AWSS3Service.cs
+++ b/OngProject/Services/AWSS3Service.cs
@@ -69,7 +69,7 @@ namespace OngProject.Services
             return new PutObjectRequest()
             {
                 BucketName = BucketName,
-                Key = file.FileName,
+                Key = "slides/" + file.FileName,
                 InputStream = file.OpenReadStream(),
                 ContentType = file.ContentType,
             };

--- a/OngProject/Services/Interfaces/IAWSS3Service.cs
+++ b/OngProject/Services/Interfaces/IAWSS3Service.cs
@@ -8,5 +8,6 @@ namespace OngProject.Services.Interfaces
         public PutObjectRequest PutRequest(IFormFile file);
         public PutObjectRequest PutObjectRequestImageBase64(string ImageBase64, string ImageName);
         public ListObjectsV2Request ListObjectV2(string prefix);
+        public string GetUrlRequest(string ImageName);
     }
 }


### PR DESCRIPTION
### Endpoint Slide Get All
#### [OT280-64](https://alkemy-labs.atlassian.net/browse/OT280-64)

```csharp
        [HttpGet()]
        public async Task<IActionResult> GetAll()
        {
            var slide = _unitOfWork.Context.Slides.AsQueryable();
            slide = slide.OrderBy(s => s.Order);
            var slides = await slide.AsNoTracking().ToListAsync();
            var slideDTO = _mapper.Map<IEnumerable<SlideListDTO>>(slides);
            return new OkObjectResult(slideDTO);
        }
```

![image](https://user-images.githubusercontent.com/88550405/190014995-07ddc29e-e109-4153-a5ee-d3f5a67093f3.png)

#### Se Modifico el Post/Slide para subir la imagen en base64 y agregar la url del AWS S3 con un time expire de 2 meses. por eso en la imagen anterior se puede ver como antes se guardaba en ImageUrl el nombre del archivo con la extensión y ahora podemos tener la url para visualizarla.
#### Las imagenes de los slides se guardan en una carpeta dentro del bucket llamada slides.